### PR TITLE
Removes alabaster theme and instead adds readthedocs theme for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,8 @@
 import sys
 import os
 
+import sphinx_rtd_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -121,7 +123,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -129,7 +131,7 @@ html_theme = 'alabaster'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-alabaster==0.7.7
 Babel==2.3.4
 codecov==2.0.3
 coverage==4.0.3
@@ -15,5 +14,6 @@ requests==2.10.0
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.4.1
+sphinx_rtd_theme==0.1.9
 tox==2.3.1
 virtualenv==15.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,6 @@ deps =
     pre-commit: pre-commit>=0.9.4,<1.0.0
     lint: pylint>=1.3.1,<2.0.0
     docs: Sphinx>=1.4.1,<2.0.0
+    docs: sphinx_rtd_theme>=0.1.9,<0.2
 recreate =
     True


### PR DESCRIPTION
# What?
1. Changes in requirement-dev.txt
2. Changes in docs/source/conf.py
3. Changes in tox.ini

# Why?
Replace the alabaster theme with readthedocs theme for docs