### PR TITLE
Modules/reafctor/content handlers

### DIFF
--- a/auto_extract/content_handlers.py
+++ b/auto_extract/content_handlers.py
@@ -26,9 +26,9 @@ class TDSContentHandler(object):
         self._tds_columns = list()
 
     @property
-    def columns(self):
+    def column_definitions(self):
         """
-        Information of columns within parsed tableau datasource
+        Column definition parsed tableau datasource
 
         Returns
         -------
@@ -39,13 +39,8 @@ class TDSContentHandler(object):
                 {
                     'local-name': local name of column,
                     'parent-name': name of the table containing column
-                    'remote-name': name of column in `parent-name`,
                     'local-type': local data type of column,
-                    'aggregation': column aggregated on,
-                    'contains-null': if column contains null values
-                    ...
                 }
-
 
         Examples
         --------
@@ -53,74 +48,24 @@ class TDSContentHandler(object):
         >>> datasource = etree.parse('sample/sample.tds').getroot()
         >>> tds_content_handler = TDSContentHandler()
         >>> tds_content_handler.parse(datasource)
-        >>> tds_content_handler.columns[:2] == [{
-        ...     'ordinal': '1',
+        >>> tds_content_handler.column_definitions[:2] == [{
         ...     'parent-name': '[TABLE_NAME]',
-        ...     'remote-type': '7',
-        ...     'aggregation': 'Year',
-        ...     'remote-alias': 'REMOTE_ALIAS1',
-        ...     'remote-name': 'REMOTE_COLUMN_NAME1',
-        ...      'attributes': {
-        ...          'attribute': [{
-        ...             'datatype': 'string',
-        ...             'name': 'DebugRemoteType',
-        ...             '_text': '"SQL_TYPE_DATE"'
-        ...           },
-        ...           {
-        ...             'datatype': 'string',
-        ...             'name': 'DebugWireType',
-        ...             '_text': '"SQL_C_TYPE_DATE"'
-        ...           },
-        ...           {
-        ...             'datatype': 'boolean',
-        ...             'name': 'TypeIsDateTime2orDate',
-        ...             '_text': 'true'
-        ...           }]
-        ...      },
         ...     'local-name': '[LOCAL_COLUMN_NAME1]',
         ...     'local-type': 'date',
-        ...     'class': 'column',
-        ...     'contains-null': 'true'
         ... },
         ... {
-        ...      'ordinal': '2',
         ...      'parent-name': '[TABLE_NAME]',
-        ...      'remote-type': '130',
-        ...      'padded-semantics': 'true',
-        ...      'aggregation': 'Count',
-        ...      'remote-alias': 'REMOTE_ALIAS2',
-        ...      'width': '100',
-        ...      'remote-name': 'REMOTE_COLUMN_NAME2',
-        ...      'attributes': {
-        ...          'attribute': [{
-        ...             'datatype': 'string',
-        ...             'name': 'DebugRemoteType',
-        ...             '_text': '"SQL_WVARCHAR"',
-        ...           },
-        ...           {
-        ...             'datatype': 'string',
-        ...             'name': 'DebugWireType',
-        ...             '_text': '"SQL_C_WCHAR"',
-        ...           },
-        ...           {
-        ...             'datatype': 'string',
-        ...             'name': 'TypeIsVarchar',
-        ...             '_text': '"true"',
-        ...           }]
-        ...      },
-        ...      'collation': {
-        ...          'flag': '2147483649',
-        ...          'name': 'LEN_RUS_S2_VWIN'
-        ...      },
         ...      'local-name': '[LOCAL_COLUMN_NAME2]',
         ...      'local-type': 'string',
-        ...      'class': 'column',
-        ...      'contains-null': 'true'
         ... }]
         True
 
         """
-        return self._tds_columns
+        return map(lambda x: {
+            'parent-name': x.get('parent-name'),
+            'local-name': x.get('local-name'),
+            'local-type': x.get('local-type')
+        }, self._tds_columns)
 
     @property
     def metadata(self):

--- a/auto_extract/content_handlers.py
+++ b/auto_extract/content_handlers.py
@@ -176,7 +176,11 @@ class TDSContentHandler(object):
             element tree representing a tableau datasource
 
         """
-        self._tds_metadata['datasource'] = tds_xml.attrib
+        self._tds_metadata['datasource'] = dict(tds_xml.attrib)
+
+        assert isinstance(self._tds_metadata['datasource'], dict), \
+            'datasource information is not dict'
+        assert len(self._tds_metadata['datasource']) != 0, 'datasource information is empty'
 
         connection_path = 'connection/named-connections/named-connection/connection'
         connections = list()

--- a/auto_extract/readers.py
+++ b/auto_extract/readers.py
@@ -69,18 +69,18 @@ class TDSReader(object):
 
         """
         table_definition = TableDefinition()
-        column_map = self.get_datasource_columns()
+        column_definitions = self.get_datasource_column_defs()
 
         table_definition.setDefaultCollation(collation)
 
-        for i, column in enumerate(column_map, start=1):
-            parent_name = column.get('parent-name')
-            local_name = column.get('local-name')
-            local_type = column.get('local-type')
+        for i, definition in enumerate(column_definitions, start=1):
+            parent_name = definition.get('parent-name')
+            local_name = definition.get('local-name')
+            local_type = definition.get('local-type')
 
-            assert parent_name is not None, 'parent-name is None at: {}:\n'.format(i) + str(column)
-            assert local_name is not None, 'local-name is None at: {}:\n'.format(i) + str(column)
-            assert local_type is not None, 'local-type is None at: {}:\n'.format(i) + str(column)
+            assert parent_name is not None, 'parent-name is None at: {}:\n'.format(i) + str(definition)
+            assert local_name is not None, 'local-name is None at: {}:\n'.format(i) + str(definition)
+            assert local_type is not None, 'local-type is None at: {}:\n'.format(i) + str(definition)
 
             column_name = '{}.{}'.format(parent_name, local_name)
             column_type = self._type_map.get(local_type, self._type_map['unicode_string'])
@@ -89,13 +89,13 @@ class TDSReader(object):
 
         return table_definition
 
-    def get_datasource_columns(self):
+    def get_datasource_column_defs(self):
         """
         Returns read tableau datasource column information
 
         Returns
         -------
-        TDSContentHandler.columns
+        TDSContentHandler.column_definitions
 
         Examples
         --------
@@ -103,13 +103,13 @@ class TDSReader(object):
         >>> tds_content_handler = TDSContentHandler()
         >>> tds_reader = TDSReader(tds_content_handler)
         >>> tds_reader.read('sample/sample.tds')
-        >>> tds_reader.get_datasource_columns() == tds_content_handler.columns
+        >>> tds_reader.get_datasource_column_defs() == tds_content_handler.column_definitions
         True
 
         """
         tds_content = self._xml_content_handler
 
-        return tds_content.columns
+        return tds_content.column_definitions
 
     def get_datasource_metadata(self):
         """


### PR DESCRIPTION
# What?
1. TDSContentHanlder:columns to TDSContentHandler:column_definitions
2. Assertion for datasource property in TDSContentHandler:metadata
3. Converting datasource property in TDSContentHandler:metadata to dict
3. Parsing with xpath, combined with xml_as_dictionary

# Why?
1. All the column properties are not important today, but someone might need them in future. Thus the xml_as_dictionary parses a complete column but exposes only parts required for filling table definition in TDSReader. Properties include, local-name, parent-name and local-type. This even helps in writing better and shorter test cases.
2. Assertions help in debugging process for datasource property. It will help us discover any tableau version mismatches in datasource parsing.
3. Datasource property was stored as a type of `lxml.etree` which is similar to a dict but not exactly a dict. It is better to keep the results in raw python types.
4. With `xml_as_dictionary` we were parsing the complete connection element tree, but it was not necessary and was prone to danger or breaks when new things are added in future version. By using xpaths we can customise and dictate rules for each version in one config file (WIP) and can iterate over the elements too instead of getting a big blob at one time.