### PR TITLE
Fixes: #13

### DIFF
--- a/auto_extract/readers.py
+++ b/auto_extract/readers.py
@@ -159,7 +159,7 @@ class TDSReader(object):
         >>> tds_reader.read('some random file') #doctest: +ELLIPSIS
         Traceback (most recent call last):
             ...
-        OSError: [Errno 2] No such file or directory: '.../some random file'
+        IOError: does not exists
 
         >>> from auto_extract.content_handlers import TDSContentHandler
         >>> tds_content_handler = TDSContentHandler()
@@ -171,10 +171,11 @@ class TDSReader(object):
 
         """
         tds_file_path = Path(tds_file)
-        absolute_path = str(tds_file_path.resolve())
 
         if not tds_file_path.exists():
             raise IOError('does not exists')
+
+        absolute_path = str(tds_file_path.resolve())
 
         if not tds_file_path.is_file():
             raise IOError('not a file')

--- a/tests/readers_test.py
+++ b/tests/readers_test.py
@@ -34,13 +34,13 @@ class TestTDSReader(unittest.TestCase):
     def test_read(self):
         """
         Asserts:
-            * Raises OSError for missing file / directory
+            * Raises IOError for missing file / directory
             * Raises IOError when file expected but folder or something other
               than file given
             * Raises IOError when file given does not have .tds extension in name
 
         """
-        with self.assertRaisesRegexp(OSError, 'No such file or directory'):
+        with self.assertRaisesRegexp(IOError, 'does not exists'):
             self.reader.read('sample/random file.tds')
 
         with self.assertRaisesRegexp(IOError, '^not a file$'):


### PR DESCRIPTION
# What?
1. Moves Path.resolve below assertion in read method
2. Changes doctest and unit tests

# Why?
1. The expected error is IOError but the method used to return OSError as Path.resolve needs file to exists first and before assertion the error is thrown by Path.resolve giving unexpected result.
2. Test cases are changed accordingly.