### PR TITLE
Fix: License in Setup.py updated to MIT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     dependency_links=[
         tableau_sdk,
     ],
-    license='Apache License (2.0)',
+    license='MIT License',
     name='auto_extract',
     packages=[
         'auto_extract',


### PR DESCRIPTION
## What
Fixes license in Setup.py: Apache License (2.0) -> MIT License

## Why
To have consistency between root and setup file