### PR TITLE
Handles different behaviour of Path object when computing absolute path

### DIFF
--- a/auto_extract/cli.py
+++ b/auto_extract/cli.py
@@ -35,20 +35,25 @@ def main(files, overwrite, prefix, suffix, output_dir):
     `FILES` include list of filenames / filepaths and it accepts characters
     like '*', anything that will result in a valid file path.
 
-    OSError will be raised otherwise.
-
     """
-    ExtractAPI.initialize()
-    tde_success_map = dict()
-
-    cols = _compute_cols(files)
     absolute_output_dir = None
 
     if output_dir is not None:
+        if not Path(output_dir).exists():
+            raise AutoExtractException('Output Directory: {!r} does not exists'.format(output_dir))
+
         absolute_output_dir = Path(output_dir).resolve()
+
+    tde_success_map = dict()
+    cols = _compute_cols(files)
+
+    ExtractAPI.initialize()
 
     with click.progressbar(files, label='Processing datasource files') as file_names:
         for file_name in file_names:
+            if not Path(file_name).exists():
+                raise AutoExtractException('File Path: {!r} does not exists'.format(file_name))
+
             absolute_path = str(Path(file_name).resolve())
 
             if absolute_path in tde_success_map:

--- a/tests/auto_extract_test.py
+++ b/tests/auto_extract_test.py
@@ -118,12 +118,13 @@ class TestAutoExtractCommand(unittest.TestCase):
         """
         Asserts:
             * Progress text is displayed
-            * OSError is thrown
+            * AutoExtractException is thrown
 
         """
         result = RUNNER.invoke(main, ['sample1.tds'])
         assert result.exit_code == -1
-        assert isinstance(result.exception, OSError)
+        assert isinstance(result.exception, AutoExtractException)
+        assert str(result.exception) == 'File Path: \'sample1.tds\' does not exists'
         assert len(self.PROGRESS_TEXT_PATTERN.findall(result.output)) == 1
 
     @isolated_filesystem
@@ -298,14 +299,15 @@ class TestAutoExtractCommand(unittest.TestCase):
     def test_with_output_dir_when_not_exist(self):  # pylint: disable=locally-disabled,invalid-name
         """
         Asserts:
-            * completes unsuccessfully with OSError
+            * completes unsuccessfully with AutoExtractException
             * File is not created
 
         """
         result = RUNNER.invoke(main, ['--output-dir', 'temp', 'sample.tds'])
         assert result.exit_code == -1
         assert not os.path.exists('temp' + os.sep + 'sample.tde')
-        assert isinstance(result.exception, OSError)
+        assert isinstance(result.exception, AutoExtractException)
+        assert str(result.exception) == 'Output Directory: \'temp\' does not exists'
         assert len(self.PROGRESS_TEXT_PATTERN.findall(result.output)) == 0
 
     @isolated_filesystem


### PR DESCRIPTION
# Why
pathlib2 Path.resolve behaves differently on Mac vs. Linux. On Mac if the absolute path does not exists, it throws OSError while on Linux it doesn't.